### PR TITLE
fix: required args

### DIFF
--- a/src/arch_blueprint/__main__.py
+++ b/src/arch_blueprint/__main__.py
@@ -11,7 +11,7 @@ def main() -> None:
     parser.add_argument(
         "root",
         type=str,
-        help="Name of root python module in project (example: 'myapp'",
+        help="Name of root python module in project (example: 'myapp')",
     )
     parser.add_argument(
         "--modules",


### PR DESCRIPTION
1. `--modules` as required.
2. typo in `--help`