### PR TITLE
feat: class-level nodes (--nodes class)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,7 @@ This project uses `uv` for environment and dependency management.
     packages (e.g. `-m 'app1.*' -m 'app2.*'`). A cross-package link is drawn only when both
     endpoints are in the selected set.
   - `--format`/`-f` defaults to `puml`; `--no-cycle-details` hides per-module edges on cycles.
+  - `--nodes`/`-n` (`module` default, or `class`) selects what a node represents.
   - `--metric NAME` (repeatable) displays a metric. A node metric (`fan_in`, `fan_out`,
     `instability`) renders as a block on each node; a link metric (`edge_weight`) renders as a label
     on each connection.
@@ -41,7 +42,7 @@ pytest) and a `test` matrix running `pytest` across Python 3.9–3.14, on push t
 asserts byte-exact output against snapshots in `tests/golden/` — the regression guard; when output
 *intentionally* changes, regenerate the affected golden file. `tests/test_units.py` covers the
 domain, metrics, analyzer, and extractors. Fixtures: `examples/project_root` (multi-root + namespace
-packages) and `tests/fixtures/cyclic` (a module cycle).
+packages), `tests/fixtures/cyclic` (a module cycle), `tests/fixtures/classes` (a class cycle).
 
 ## Git conventions
 
@@ -57,11 +58,12 @@ packages) and `tests/fixtures/cyclic` (a module cycle).
    `project_dir` to `sys.path`, resolves every `--modules` pattern to a top-level package, and builds
    the grimp graph (multiple roots supported). It handles PEP 420 namespace packages grimp can't
    build directly (expands them, skips ones with no analyzable source with a stderr warning). It
-   exposes `selected_modules()` and `imports_of(module)`.
+   exposes `selected_modules()`, `imports_of(module)`, and `module_file(module)`.
 2. **Extract** (`extract/`) — a `GraphExtractor` (Protocol in `extract/base.py`) turns the source
-   into a `BlueprintGraph`. `ModuleExtractor` emits one node per selected module. An extractor
-   assigns each `Node` its `NodeKind` and namespace, so a new node kind is added by writing another
-   extractor — the domain, metrics, and renderers do not change.
+   into a `BlueprintGraph`. `ModuleExtractor` emits one node per selected module; `ClassExtractor`
+   parses module source with `ast` and emits one node per class (grouped under its module). Both
+   produce the same `Node`/`Edge` types, so everything downstream is shared. The CLI picks one via
+   the `_EXTRACTORS` map in `__main__.py` (`--nodes`).
 3. **Domain + metrics** — `domain/` holds the data model: `Node` (id, `NodeKind`, namespace — frozen
    and hashable, **no metric fields**), `Edge`, `Link`, `Cycle`, and `BlueprintGraph` (aggregates
    edges into `Link`s via `build_links`, stores metrics in side maps keyed by id/namespace-pair).

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Commands
 ```shell
 arch-blueprint --help
 usage: arch-blueprint [-h] --modules [MODULES ...] [--format {puml,d2}]
-                      [--metric NAME] [--no-cycle-details]
+                      [--nodes {module,class}] [--metric NAME]
+                      [--no-cycle-details]
                       project_dir
 
 Generate architecture diagrams for Python applications
@@ -30,13 +31,20 @@ options:
                         'myapp.*.*.models.*', 'myapp.somemodule.**')
   --format, -f {puml,d2}
                         Output format. Possible values: ['puml', 'd2']
+  --nodes, -n {module,class}
+                        What each node represents. 'module' graphs module-
+                        level imports; 'class' graphs classes (grouped under
+                        their modules).
   --metric NAME         Show a metric block on each node (repeatable). e.g.
                         --metric fan_in
   --no-cycle-details    Hide detailed information for cyclic dependencies
 ```
 
-### Metrics
+### Node kinds and metrics
 
+- `--nodes module` (default) graphs module-level imports.
+- `--nodes class` graphs classes as nodes, grouped under their defining module;
+  links and cycles are drawn at the module level with class names in the details.
 - `--metric NAME` adds a per-node metric block (repeatable). Built-in metrics:
   `fan_in`, `fan_out`, `instability`. New metrics are added as self-contained
   plugins under `src/arch_blueprint/metrics/` and registered in

--- a/src/arch_blueprint/__main__.py
+++ b/src/arch_blueprint/__main__.py
@@ -3,6 +3,8 @@ from types import MappingProxyType
 from typing import Final
 
 from arch_blueprint.blueprint import ArchBlueprint
+from arch_blueprint.extract.base import GraphExtractor
+from arch_blueprint.extract.class_extractor import ClassExtractor
 from arch_blueprint.extract.module_extractor import ModuleExtractor
 from arch_blueprint.metrics import MetricDisplay, default_registry, default_renders
 from arch_blueprint.renderer.base import (
@@ -17,6 +19,13 @@ _RENDERERS: Final[MappingProxyType[str, type[BlueprintRenderer]]] = MappingProxy
     {
         "puml": PlantUmlRenderer,
         "d2": D2LangRenderer,
+    },
+)
+
+_EXTRACTORS: Final[MappingProxyType[str, type[GraphExtractor]]] = MappingProxyType(
+    {
+        "module": ModuleExtractor,
+        "class": ClassExtractor,
     },
 )
 
@@ -51,6 +60,17 @@ def main() -> None:
         default="puml",
         choices=_RENDERERS.keys(),
         help=f"Output format. Possible values: {list(_RENDERERS.keys())}",
+    )
+    parser.add_argument(
+        "--nodes",
+        "-n",
+        required=False,
+        default="module",
+        choices=_EXTRACTORS.keys(),
+        help=(
+            "What each node represents. 'module' graphs module-level imports; "
+            "'class' graphs classes (grouped under their modules)."
+        ),
     )
     parser.add_argument(
         "--metric",
@@ -88,7 +108,7 @@ def main() -> None:
         project_dir=args.project_dir,
         target_names=args.modules,
         renderer=renderer,
-        extractor_cls=ModuleExtractor,
+        extractor_cls=_EXTRACTORS[args.nodes],
         registry=registry,
     ).run()
     print(result)  # noqa: T201

--- a/src/arch_blueprint/blueprint.py
+++ b/src/arch_blueprint/blueprint.py
@@ -13,8 +13,8 @@ from arch_blueprint.renderer.base import BlueprintRenderer
 class ArchBlueprint:
     """Generates architecture blueprints for Python applications.
 
-    Drives the pipeline: build the import source, extract a graph, compute
-    metrics, and render.
+    Drives the pipeline: build the import source, extract a graph (modules or
+    classes), compute metrics, and render.
     """
 
     def __init__(

--- a/src/arch_blueprint/domain/node.py
+++ b/src/arch_blueprint/domain/node.py
@@ -8,16 +8,18 @@ class NodeKind(Enum):
     """The kind of entity a node represents in the blueprint graph."""
 
     MODULE = "module"
+    CLASS = "class"
 
 
 @dataclass(frozen=True)
 class Node:
-    """A single entity in the blueprint graph.
+    """A single entity in the blueprint graph (a module or a class).
 
     A node is identified solely by ``id`` (its dotted, importable name), which
     keeps it hashable and lets metrics be stored alongside it without affecting
     equality. ``namespace`` is assigned by the extractor rather than derived from
-    ``id`` so that different node kinds can group differently.
+    ``id`` so that different node kinds can group differently (e.g. a class groups
+    under its defining module).
     """
 
     id: str

--- a/src/arch_blueprint/extract/__init__.py
+++ b/src/arch_blueprint/extract/__init__.py
@@ -1,8 +1,10 @@
 from arch_blueprint.extract.base import GraphExtractor
+from arch_blueprint.extract.class_extractor import ClassExtractor
 from arch_blueprint.extract.module_extractor import ModuleExtractor
 from arch_blueprint.extract.source import GrimpSource
 
 __all__ = [
+    "ClassExtractor",
     "GraphExtractor",
     "GrimpSource",
     "ModuleExtractor",

--- a/src/arch_blueprint/extract/class_extractor.py
+++ b/src/arch_blueprint/extract/class_extractor.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import ast
+from typing import Optional
+
+from arch_blueprint.domain.graph import BlueprintGraph, Edge
+from arch_blueprint.domain.node import Node, NodeKind
+from arch_blueprint.extract.base import parent_namespace
+from arch_blueprint.extract.source import GrimpSource
+
+
+class ClassExtractor:
+    """Extracts a class-level graph from the source of the selected modules.
+
+    Each top-level class becomes a node grouped under its defining module. A
+    class depends on another *selected* class when it references it through base
+    classes, annotations, or calls — resolved via the module's imports. Because a
+    class's namespace is its module, class edges feed the same module-level
+    link/cycle pipeline as :class:`ModuleExtractor`, with class names shown in the
+    cycle details.
+
+    The relationship rules live in :meth:`_referenced_class_ids`, deliberately
+    isolated so they can evolve (e.g. to add composition or usage) without
+    touching the rest of the pipeline.
+    """
+
+    def __init__(self, source: GrimpSource) -> None:
+        self.source = source
+
+    def extract(self) -> BlueprintGraph:
+        modules = self.source.selected_modules()
+        trees: dict[str, ast.Module] = {}
+        module_classes: dict[str, list[ast.ClassDef]] = {}
+        class_ids: set[str] = set()
+
+        for module in modules:
+            tree = self._parse(module)
+            if tree is None:
+                continue
+            trees[module] = tree
+            classes = [n for n in tree.body if isinstance(n, ast.ClassDef)]
+            module_classes[module] = classes
+            class_ids.update(f"{module}.{cls.name}" for cls in classes)
+
+        nodes = [
+            Node(id=f"{module}.{cls.name}", kind=NodeKind.CLASS, namespace=module)
+            for module in modules
+            if module in trees
+            for cls in module_classes[module]
+        ]
+
+        edges: set[Edge] = set()
+        for module, tree in trees.items():
+            import_map = self._build_import_map(tree, module)
+            local_classes = {cls.name for cls in module_classes[module]}
+            for cls in module_classes[module]:
+                source_id = f"{module}.{cls.name}"
+                referenced = self._referenced_class_ids(
+                    cls,
+                    module,
+                    import_map,
+                    local_classes,
+                    class_ids,
+                )
+                for target_id in referenced:
+                    target_module = parent_namespace(target_id)
+                    if target_module != module:
+                        edges.add(
+                            Edge(
+                                source=source_id,
+                                target=target_id,
+                                source_namespace=module,
+                                target_namespace=target_module,
+                            ),
+                        )
+
+        return BlueprintGraph(nodes=nodes, edges=edges)
+
+    def _parse(self, module: str) -> Optional[ast.Module]:
+        path = self.source.module_file(module)
+        if path is None or path.suffix != ".py":
+            return None
+        try:
+            return ast.parse(path.read_text(encoding="utf-8"))
+        except (OSError, SyntaxError):
+            return None
+
+    def _referenced_class_ids(
+        self,
+        cls: ast.ClassDef,
+        module: str,
+        import_map: dict[str, str],
+        local_classes: set[str],
+        class_ids: set[str],
+    ) -> set[str]:
+        """Class ids referenced by ``cls`` (bases, annotations, calls)."""
+        result: set[str] = set()
+        for node in ast.walk(cls):
+            candidate: Optional[str] = None
+            if isinstance(node, ast.Name):
+                candidate = self._resolve_name(
+                    node.id,
+                    module,
+                    import_map,
+                    local_classes,
+                )
+            elif isinstance(node, ast.Attribute):
+                candidate = self._resolve_attribute(node, import_map)
+            if candidate is not None and candidate in class_ids:
+                result.add(candidate)
+        return result
+
+    @staticmethod
+    def _resolve_name(
+        name: str,
+        module: str,
+        import_map: dict[str, str],
+        local_classes: set[str],
+    ) -> Optional[str]:
+        if name in import_map:
+            return import_map[name]
+        if name in local_classes:
+            return f"{module}.{name}"
+        return None
+
+    def _resolve_attribute(
+        self,
+        node: ast.Attribute,
+        import_map: dict[str, str],
+    ) -> Optional[str]:
+        dotted = self._attribute_to_dotted(node)
+        if dotted is None:
+            return None
+        head, _, rest = dotted.partition(".")
+        if head not in import_map:
+            return None
+        base = import_map[head]
+        return f"{base}.{rest}" if rest else base
+
+    @staticmethod
+    def _attribute_to_dotted(node: ast.Attribute) -> Optional[str]:
+        parts: list[str] = []
+        current: ast.expr = node
+        while isinstance(current, ast.Attribute):
+            parts.append(current.attr)
+            current = current.value
+        if not isinstance(current, ast.Name):
+            return None
+        parts.append(current.id)
+        parts.reverse()
+        return ".".join(parts)
+
+    def _build_import_map(self, tree: ast.Module, module: str) -> dict[str, str]:
+        """Map each locally bound name to the dotted target it refers to."""
+        mapping: dict[str, str] = {}
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    if alias.asname:
+                        mapping[alias.asname] = alias.name
+                    else:
+                        top = alias.name.split(".")[0]
+                        mapping[top] = top
+            elif isinstance(node, ast.ImportFrom):
+                base = self._resolve_from_base(node, module)
+                if base is None:
+                    continue
+                for alias in node.names:
+                    bound = alias.asname or alias.name
+                    mapping[bound] = f"{base}.{alias.name}"
+        return mapping
+
+    @staticmethod
+    def _resolve_from_base(node: ast.ImportFrom, module: str) -> Optional[str]:
+        if node.level == 0:
+            return node.module
+        parts = module.split(".")
+        if node.level > len(parts):
+            return None
+        base_parts = parts[: len(parts) - node.level]
+        if node.module:
+            base_parts = base_parts + node.module.split(".")
+        return ".".join(base_parts) if base_parts else None

--- a/src/arch_blueprint/extract/source.py
+++ b/src/arch_blueprint/extract/source.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib
+import importlib.util
 import sys
 from collections.abc import Iterable, Sequence
 from pathlib import Path
@@ -14,7 +15,8 @@ class GrimpSource:
     """Builds and exposes a grimp import graph for the selected target packages.
 
     Encapsulates all the sys.path / package-resolution mechanics so extractors
-    can work against a clean interface (the selected modules and their imports).
+    can work against a clean interface (selected modules, their imports, and the
+    source file of any module).
     """
 
     def __init__(
@@ -62,6 +64,16 @@ class GrimpSource:
         for descendant in descendants:
             result.update(self.graph.find_modules_directly_imported_by(descendant))
         return result
+
+    def module_file(self, module: str) -> Optional[Path]:
+        """Resolve a module's source file without importing/executing it."""
+        try:
+            spec = importlib.util.find_spec(module)
+        except (ImportError, AttributeError, ValueError):
+            return None
+        if spec is None or spec.origin is None:
+            return None
+        return Path(spec.origin)
 
     def _resolve_grimp_packages(self) -> list[str]:
         packages: list[str] = []

--- a/src/arch_blueprint/renderer/puml.py
+++ b/src/arch_blueprint/renderer/puml.py
@@ -39,7 +39,7 @@ _CYCLE_NOTE_TEMPLATE: Final = Template(
 )
 
 # PlantUML stereotype spot letter per node kind.
-_SPOT_LETTER: Final = {NodeKind.MODULE: "M"}
+_SPOT_LETTER: Final = {NodeKind.MODULE: "M", NodeKind.CLASS: "C"}
 
 
 class PlantUmlRenderer(BlueprintRenderer):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,9 +10,11 @@ GOLDEN_DIR = Path(__file__).resolve().parent / "golden"
 EXAMPLE_PROJECT = REPO_ROOT / "examples" / "project_root"
 _FIXTURES = Path(__file__).resolve().parent / "fixtures"
 CYCLIC_PROJECT = _FIXTURES / "cyclic"
+CLASSES_PROJECT = _FIXTURES / "classes"
 
 EXAMPLE_MODULES = ["-m", "app1.*", "-m", "app2.*", "-m", "plugins.**"]
 CYCLIC_MODULES = ["-m", "pkg_a.*", "-m", "pkg_b.*"]
+CLASSES_MODULES = ["-m", "shop.*"]
 SHOW_METRICS = ["--metric", "fan_in", "--metric", "fan_out", "--metric", "instability"]
 SHOW_LINK_METRIC = ["--metric", "edge_weight"]
 
@@ -36,6 +38,7 @@ SCENARIOS = [
     Scenario(
         "cyclic_nodetails", CYCLIC_PROJECT, [*CYCLIC_MODULES, "--no-cycle-details"]
     ),
+    Scenario("classes", CLASSES_PROJECT, [*CLASSES_MODULES, "--nodes", "class"]),
     Scenario("metrics", CYCLIC_PROJECT, [*CYCLIC_MODULES, *SHOW_METRICS]),
     Scenario("link_metrics", EXAMPLE_PROJECT, [*EXAMPLE_MODULES, *SHOW_LINK_METRIC]),
 ]

--- a/tests/fixtures/classes/shop/billing.py
+++ b/tests/fixtures/classes/shop/billing.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from shop.models import Order
+
+
+class Payment:
+    def __init__(self, order: Order) -> None:
+        self.order = order

--- a/tests/fixtures/classes/shop/models.py
+++ b/tests/fixtures/classes/shop/models.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from shop.billing import Payment
+
+
+class Customer:
+    name: str
+
+
+class Order:
+    customer: Customer
+
+    def pay(self, payment: Payment) -> None:
+        self.payment = payment

--- a/tests/golden/d2/classes.d2
+++ b/tests/golden/d2/classes.d2
@@ -1,0 +1,52 @@
+direction: right
+shop.billing.Payment: {
+  shape: class
+  style: {
+    fill: "#1ABC9C"
+  }
+}
+
+shop.models.Customer: {
+  shape: class
+  style: {
+    fill: "#1ABC9C"
+  }
+}
+
+shop.models.Order: {
+  shape: class
+  style: {
+    fill: "#1ABC9C"
+  }
+}
+shop.billing <-> shop.models: CYCLE {style.stroke: "#C0392B"; style.stroke-width: 4}
+"Cycle Details": {
+  style.fill: "#FEF9E7"
+  style.stroke: "#F39C12"
+  style.stroke-width: 2
+  style.border-radius: 12
+
+  grid: {
+    label: ""
+    grid-rows: 1
+    grid-gap: 32
+    style.stroke: transparent
+    style.fill: transparent
+
+    cycle_shop_billing_shop_models: |md
+      ### shop.billing ↔ shop.models
+
+      **shop.billing → shop.models:**
+
+      - Payment → Order
+
+      **shop.models → shop.billing:**
+
+      - Order → Payment
+    | {
+      style.fill: "#FADBD8"
+      style.stroke: "#C0392B"
+      style.border-radius: 8
+    }
+  }
+}

--- a/tests/golden/puml/classes.puml
+++ b/tests/golden/puml/classes.puml
@@ -1,0 +1,19 @@
+@startuml
+!theme amiga
+
+top to bottom direction
+hide empty members
+
+class shop.billing.Payment <<(C, #1ABC9C)>>
+class shop.models.Customer <<(C, #1ABC9C)>>
+class shop.models.Order <<(C, #1ABC9C)>>
+
+shop.billing <-[#C0392B,bold]-> shop.models
+note on link
+  **shop.billing -> shop.models:**
+  - Payment → Order
+  **shop.models -> shop.billing:**
+  - Order → Payment
+end note
+@enduml
+

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -6,6 +6,7 @@ from arch_blueprint.analyze.cycles import CycleAnalyzer
 from arch_blueprint.domain.graph import BlueprintGraph, Edge, build_links
 from arch_blueprint.domain.node import Node, NodeKind
 from arch_blueprint.extract.base import common_depth_namespaces, parent_namespace
+from arch_blueprint.extract.class_extractor import ClassExtractor
 from arch_blueprint.extract.module_extractor import ModuleExtractor
 from arch_blueprint.extract.source import GrimpSource
 from arch_blueprint.metrics import (
@@ -20,7 +21,7 @@ from arch_blueprint.metrics.fan_out import FanOutMetric
 from arch_blueprint.metrics.instability import InstabilityMetric
 from arch_blueprint.metrics.render import EdgeLabelRender, TextRowRender
 from arch_blueprint.renderer.base import RendererOptions
-from tests.conftest import CYCLIC_PROJECT
+from tests.conftest import CLASSES_PROJECT, CYCLIC_PROJECT
 
 
 def _edge(source: str, target: str, src_ns: str, tgt_ns: str) -> Edge:
@@ -190,3 +191,18 @@ def test_module_extractor_builds_cycle():
     assert all(node.kind is NodeKind.MODULE for node in graph.nodes)
     cycles = CycleAnalyzer.detect_cycles(graph.links)
     assert len(cycles) == 1
+
+
+def test_class_extractor_finds_classes_and_cross_module_edges():
+    source = GrimpSource(str(CLASSES_PROJECT), ["shop.*"])
+    graph = ClassExtractor(source).extract()
+    ids = {node.id for node in graph.nodes}
+    assert ids == {"shop.models.Customer", "shop.models.Order", "shop.billing.Payment"}
+    assert all(node.kind is NodeKind.CLASS for node in graph.nodes)
+    # Order -> Payment (annotation) and Payment -> Order (annotation) form a cycle.
+    cycles = CycleAnalyzer.detect_cycles(graph.links)
+    assert len(cycles) == 1
+    assert {cycles[0].namespace_from, cycles[0].namespace_to} == {
+        "shop.models",
+        "shop.billing",
+    }


### PR DESCRIPTION
> **Stack:** 2/2, on top of #22 — merge that one first. This PR targets
> `refactor/extensible-metrics-and-node-kinds`, so its diff shows only the
> class-node work.

## Why

#22 turned node construction into an extension point: an extractor decides what
a node is, and assigns its kind and namespace. This PR uses that point to add a
second node kind — a class — so a diagram can show class-level structure instead
of module-level imports.

## What changed

- **`ClassExtractor`** (`extract/class_extractor.py`) — parses each selected
  module's source with `ast` (no import, no execution) and emits one node per
  top-level class, with the defining module as its namespace. Edges come from
  base classes, annotations, and names referenced in class bodies, resolved
  through the module's import map. Links and cycles stay at the module level,
  with class names in the cycle details.
- **`--nodes`/`-n`** — selects the extractor via the `_EXTRACTORS` map in
  `__main__.py` (`module` default, or `class`).
- **`NodeKind.CLASS`** — renders with the `C` stereotype spot in PlantUML
  (`M` for modules).
- **`GrimpSource.module_file()`** — resolves a module's source file via
  `importlib.util.find_spec`, without importing it.
- **Tests** — new `tests/fixtures/classes` fixture (a class-level cycle:
  `Order → Payment → Order` across two modules), a `classes` golden scenario for
  both formats, and a unit test for the extractor.

Nothing in the domain, metrics, analyzer, or renderer cores changes — that's the
point of the split. The whole diff is a new extractor plus its wiring.

## Example

```
$ arch-blueprint tests/fixtures/classes -m 'shop.*' -n class
class shop.billing.Payment <<(C, #1ABC9C)>>
class shop.models.Customer <<(C, #1ABC9C)>>
class shop.models.Order <<(C, #1ABC9C)>>

shop.billing <-[#C0392B,bold]-> shop.models
note on link
  **shop.billing -> shop.models:**
  - Payment → Order
  **shop.models -> shop.billing:**
  - Order → Payment
end note
```

## Compatibility

Additive. The default is `--nodes module`, and module output is unchanged.

## Verification

- `uv run pre-commit run -a` — ruff, ruff format, strict mypy, pytest: green.
- `uv run pytest` — 30 tests: green (27 from #22 plus 3 class scenarios).
