### PR TITLE
feat: report CLI failures properly and stop dropping metrics on cycles

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,16 +26,22 @@ jobs:
 
   test:
     name: Tests
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest]
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        # One Windows leg: its console is not UTF-8, and diagram output contains
+        # arrows. Without it an encoding regression is invisible here.
+        include:
+          - os: windows-latest
+            python-version: '3.12'
     steps:
       - uses: actions/checkout@v5
         with:
           persist-credentials: false
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}

--- a/src/arch_blueprint/__main__.py
+++ b/src/arch_blueprint/__main__.py
@@ -1,10 +1,13 @@
 import argparse
+import sys
+from pathlib import Path
 from types import MappingProxyType
-from typing import Final
+from typing import Final, NoReturn
 
 from arch_blueprint.blueprint import ArchBlueprint
 from arch_blueprint.extract.module_extractor import ModuleExtractor
 from arch_blueprint.metrics import (
+    MetricConfigError,
     MetricDisplay,
     build_render_plan,
     default_registry,
@@ -24,6 +27,32 @@ _RENDERERS: Final[MappingProxyType[str, type[BlueprintRenderer]]] = MappingProxy
         "d2": D2LangRenderer,
     },
 )
+
+#: Bad input from the user; 1 is reserved for an analysis that could not finish.
+_EXIT_USAGE: Final = 2
+_EXIT_FAILURE: Final = 1
+
+
+def _abort(message: str, code: int) -> NoReturn:
+    """Report a failure the way a CLI should: one line on stderr, no traceback."""
+    sys.stderr.write(f"arch-blueprint: {message}\n")
+    raise SystemExit(code)
+
+
+def _write(text: str) -> None:
+    """Write UTF-8 regardless of the console's encoding.
+
+    Diagram output contains arrows, so printing through a non-UTF-8 stdout (a
+    Windows console, a locale-restricted CI) raises UnicodeEncodeError and the
+    run dies after doing all the work.
+    """
+    payload = f"{text}\n".encode()
+    buffer = getattr(sys.stdout, "buffer", None)
+    if buffer is None:  # a stdout replacement without a byte layer
+        sys.stdout.write(f"{text}\n")
+        return
+    buffer.write(payload)
+    buffer.flush()
 
 
 def main() -> None:
@@ -78,27 +107,45 @@ def main() -> None:
     )
     args = parser.parse_args()
 
+    if not Path(args.project_dir).is_dir():
+        _abort(f"no such project directory: {args.project_dir}", _EXIT_USAGE)
+
     options = RendererOptions(
         depth_colors=DEFAULT_OPTIONS.depth_colors,
         show_cycle_details=args.cycle_details,
     )
     registry = default_registry()
     renderer_cls = _RENDERERS[args.format]
-    plan = build_render_plan(
-        registry=registry,
-        renders=default_renders(),
-        display=MetricDisplay(shown=tuple(args.metrics)),
-        fmt=renderer_cls.fmt,
-    )
-    result = ArchBlueprint(
+    try:
+        plan = build_render_plan(
+            registry=registry,
+            renders=default_renders(),
+            display=MetricDisplay(shown=tuple(args.metrics)),
+            fmt=renderer_cls.fmt,
+        )
+    except MetricConfigError as error:
+        _abort(str(error), _EXIT_USAGE)
+
+    blueprint = ArchBlueprint(
         project_dir=args.project_dir,
         target_names=args.modules,
         renderer=renderer_cls(plan=plan, options=options),
         extractor_factory=ModuleExtractor,
         registry=registry,
         metric_names=plan.required_metrics,
-    ).run()
-    print(result)  # noqa: T201
+    )
+    try:
+        graph = blueprint.build()
+    except ImportError as error:
+        _abort(str(error), _EXIT_USAGE)
+    except OSError as error:
+        _abort(f"could not analyze {args.project_dir}: {error}", _EXIT_FAILURE)
+
+    if not graph.nodes:
+        patterns = ", ".join(repr(pattern) for pattern in args.modules)
+        _abort(f"no modules matched: {patterns}", _EXIT_USAGE)
+
+    _write(blueprint.render(graph))
 
 
 if __name__ == "__main__":

--- a/src/arch_blueprint/blueprint.py
+++ b/src/arch_blueprint/blueprint.py
@@ -4,6 +4,7 @@ from collections.abc import Callable, Iterable, Sequence
 from typing import Optional
 
 from arch_blueprint.analyze.cycles import CycleAnalyzer
+from arch_blueprint.domain.graph import BlueprintGraph
 from arch_blueprint.extract.base import GraphExtractor
 from arch_blueprint.extract.module_extractor import ModuleExtractor
 from arch_blueprint.extract.source import GrimpSource
@@ -36,10 +37,20 @@ class ArchBlueprint:
         # render plan actually needs, color metric included.
         self.metric_names = metric_names
 
-    def run(self) -> str:
+    def build(self) -> BlueprintGraph:
+        """Everything up to rendering: extract, compute metrics, analyze.
+
+        Exposed separately so a caller can inspect the graph — the CLI needs to
+        know an empty selection produced nothing before it prints a diagram.
+        """
         source = GrimpSource(self.project_dir, self.target_names)
-        extractor = self.extractor_factory(source)
-        graph = extractor.extract()
+        graph = self.extractor_factory(source).extract()
         self.registry.compute(graph, self.metric_names)
         graph.cycles = CycleAnalyzer.detect_cycles(graph.links)
+        return graph
+
+    def render(self, graph: BlueprintGraph) -> str:
         return self.renderer.render(graph)
+
+    def run(self) -> str:
+        return self.render(self.build())

--- a/src/arch_blueprint/renderer/base.py
+++ b/src/arch_blueprint/renderer/base.py
@@ -149,7 +149,11 @@ class BlueprintRenderer(ABC):
 
             cycle_key = frozenset(pair)
             if cycle_key in cycle_map:
-                rendered = self._format_cycle(cycle_map[cycle_key])
+                cycle = cycle_map[cycle_key]
+                rendered = self._format_cycle(
+                    cycle,
+                    self._cycle_decoration(graph, cycle),
+                )
                 links.append(rendered.inline)
                 if rendered.deferred is not None:
                     deferred.append(rendered.deferred)
@@ -167,14 +171,43 @@ class BlueprintRenderer(ABC):
         graph: BlueprintGraph,
         pair: tuple[str, str],
     ) -> LinkDecoration:
-        metrics = graph.link_metrics.get(pair, {})
+        return self._decorate(graph.link_metrics.get(pair, {}))
+
+    def _cycle_decoration(
+        self,
+        graph: BlueprintGraph,
+        cycle: Cycle,
+    ) -> LinkDecoration:
+        """Decorate a cycle with both directions' values, forward first.
+
+        A cycle is one drawn connection standing for two links, so a link metric
+        has two values. Showing one of them would make the golden freeze an
+        arbitrary choice; they are combined as ``forward/backward``, matching the
+        order the cycle's own detail block lists them in.
+        """
+        forward = graph.link_metrics.get((cycle.namespace_from, cycle.namespace_to), {})
+        backward = graph.link_metrics.get(
+            (cycle.namespace_to, cycle.namespace_from),
+            {},
+        )
+        combined: dict[str, MetricValue] = {}
+        for name in {*forward, *backward}:
+            if name in forward and name in backward:
+                combined[name] = f"{forward[name]}/{backward[name]}"
+            elif name in forward:
+                combined[name] = forward[name]
+            else:
+                combined[name] = backward[name]
+        return self._decorate(combined)
+
+    def _decorate(self, values: Mapping[str, MetricValue]) -> LinkDecoration:
         ctx = RenderContext(fmt=self.plan.fmt)
         labels: list[str] = []
         styles: list[str] = []
         for item in self.plan.link_items:
-            if item.name not in metrics:
+            if item.name not in values:
                 continue
-            fragment = item.plugin.render(ctx, item.name, metrics[item.name])
+            fragment = item.plugin.render(ctx, item.name, values[item.name])
             if fragment is None:
                 continue
             if fragment.text:
@@ -199,8 +232,8 @@ class BlueprintRenderer(ABC):
         ...
 
     @abstractmethod
-    def _format_cycle(self, cycle: Cycle) -> CycleRender:
-        """Format a bidirectional cycle between namespaces."""
+    def _format_cycle(self, cycle: Cycle, decoration: LinkDecoration) -> CycleRender:
+        """Format a bidirectional cycle between namespaces, with any decoration."""
         ...
 
     @abstractmethod

--- a/src/arch_blueprint/renderer/d2.py
+++ b/src/arch_blueprint/renderer/d2.py
@@ -15,8 +15,20 @@ from arch_blueprint.renderer.base import (
 from arch_blueprint.renderer.cycles import cycle_detail_sections
 
 _CYCLE_CONNECTION_TEMPLATE: Final = Template(
-    '$ns_a <-> $ns_b: CYCLE {style.stroke: "$color"; style.stroke-width: 4}',
+    '$ns_a <-> $ns_b: $label {style.stroke: "$color"; style.stroke-width: 4}',
 )
+
+#: Characters that end or nest a D2 statement, so a bare label cannot contain them.
+_LABEL_SPECIALS: Final = frozenset(';{}|#"')
+
+
+def _quote_label(label: str) -> str:
+    """Quote a connection label that would otherwise terminate the statement."""
+    if not _LABEL_SPECIALS.intersection(label):
+        return label
+    escaped = label.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
 
 _CYCLE_NOTE_COLOR: Final = "#FADBD8"
 _CYCLE_CONTAINER_FILL: Final = "#FEF9E7"
@@ -92,15 +104,19 @@ class D2LangRenderer(BlueprintRenderer):
     ) -> str:
         link = f"{source} -> {target}"
         if decoration.labels:
-            link = f"{link}: {'; '.join(decoration.labels)}"
+            link = f"{link}: {_quote_label(', '.join(decoration.labels))}"
         if decoration.styles:
             link = f"{link} {{{'; '.join(decoration.styles)}}}"
         return link
 
-    def _format_cycle(self, cycle: Cycle) -> CycleRender:
+    def _format_cycle(self, cycle: Cycle, decoration: LinkDecoration) -> CycleRender:
+        label = "CYCLE"
+        if decoration.labels:
+            label = f"{label} {' '.join(decoration.labels)}"
         connection = _CYCLE_CONNECTION_TEMPLATE.substitute(
             ns_a=cycle.namespace_from,
             ns_b=cycle.namespace_to,
+            label=_quote_label(label),
             color=CYCLE_HIGHLIGHT_COLOR,
         )
         if not self.options.show_cycle_details:

--- a/src/arch_blueprint/renderer/puml.py
+++ b/src/arch_blueprint/renderer/puml.py
@@ -67,9 +67,11 @@ class PlantUmlRenderer(BlueprintRenderer):
             link = f"{link} : {' '.join(decoration.labels)}"
         return link
 
-    def _format_cycle(self, cycle: Cycle) -> CycleRender:
+    def _format_cycle(self, cycle: Cycle, decoration: LinkDecoration) -> CycleRender:
         color = CYCLE_HIGHLIGHT_COLOR
         link = f"{cycle.namespace_from} <-[{color},bold]-> {cycle.namespace_to}"
+        if decoration.labels:
+            link = f"{link} : {' '.join(decoration.labels)}"
 
         if not self.options.show_cycle_details:
             return CycleRender(inline=link)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Optional
 
 from arch_blueprint.domain.graph import BlueprintGraph, Edge
 from arch_blueprint.domain.node import Node, NodeKind
@@ -67,6 +69,12 @@ SCENARIOS = [
     # Single root with deep namespaces: link endpoints collide byte-for-byte with node
     # ids and nest inside one another — the two cases that break naive grouping.
     Scenario("deep", DEEP_PROJECT, DEEP_MODULES),
+    # A link metric on a connection that is a cycle: two directions, two values.
+    Scenario(
+        "cyclic_link_metrics",
+        CYCLIC_PROJECT,
+        [*CYCLIC_MODULES, *SHOW_LINK_METRIC],
+    ),
 ]
 
 
@@ -84,7 +92,12 @@ class CliResult:
     returncode: int
 
 
-def run_cli(project_dir: Path, *args: str, check: bool = True) -> CliResult:
+def run_cli(
+    project_dir: Path,
+    *args: str,
+    check: bool = True,
+    extra_env: Optional[dict[str, str]] = None,
+) -> CliResult:
     """Run the arch-blueprint CLI end-to-end.
 
     Invoked as a subprocess so a run is isolated from whatever the CLI does to
@@ -98,6 +111,7 @@ def run_cli(project_dir: Path, *args: str, check: bool = True) -> CliResult:
         encoding="utf-8",
         check=check,
         cwd=REPO_ROOT,
+        env={**os.environ, **extra_env} if extra_env else None,
     )
     return CliResult(
         stdout=result.stdout,

--- a/tests/golden/d2/cyclic_link_metrics.d2
+++ b/tests/golden/d2/cyclic_link_metrics.d2
@@ -1,0 +1,53 @@
+direction: right
+pkg_a.core: {
+  shape: class
+  style: {
+    fill: "#2ECC71"
+  }
+}
+
+pkg_a.services: {
+  shape: class
+  style: {
+    fill: "#2ECC71"
+  }
+}
+
+pkg_b.util: {
+  shape: class
+  style: {
+    fill: "#2ECC71"
+  }
+}
+pkg_a <-> pkg_b: CYCLE edge_weight=2/1 {style.stroke: "#C0392B"; style.stroke-width: 4}
+"Cycle Details": {
+  style.fill: "#FEF9E7"
+  style.stroke: "#F39C12"
+  style.stroke-width: 2
+  style.border-radius: 12
+
+  grid: {
+    label: ""
+    grid-rows: 1
+    grid-gap: 32
+    style.stroke: transparent
+    style.fill: transparent
+
+    cycle_pkg_a_pkg_b: |md
+      ### pkg_a ↔ pkg_b
+
+      **pkg_a → pkg_b:**
+
+      - core → util
+      - services → util
+
+      **pkg_b → pkg_a:**
+
+      - util → core
+    | {
+      style.fill: "#FADBD8"
+      style.stroke: "#C0392B"
+      style.border-radius: 8
+    }
+  }
+}

--- a/tests/golden/puml/cyclic_link_metrics.puml
+++ b/tests/golden/puml/cyclic_link_metrics.puml
@@ -1,0 +1,20 @@
+@startuml
+!theme amiga
+
+top to bottom direction
+hide empty members
+
+class pkg_a.core <<(M, #2ECC71)>>
+class pkg_a.services <<(M, #2ECC71)>>
+class pkg_b.util <<(M, #2ECC71)>>
+
+pkg_a <-[#C0392B,bold]-> pkg_b : edge_weight=2/1
+note on link
+  **pkg_a -> pkg_b:**
+  - core → util
+  - services → util
+  **pkg_b -> pkg_a:**
+  - util → core
+end note
+@enduml
+

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.conftest import (
+    CYCLIC_MODULES,
+    CYCLIC_PROJECT,
+    EXAMPLE_MODULES,
+    EXAMPLE_PROJECT,
+    run_cli,
+)
+
+_USAGE_ERROR = 2
+
+
+def test_successful_run_reports_success() -> None:
+    result = run_cli(EXAMPLE_PROJECT, *EXAMPLE_MODULES)
+    assert result.returncode == 0
+    assert result.stdout.startswith("@startuml")
+    assert result.stderr == ""
+
+
+@pytest.mark.parametrize(
+    ("project", "args", "expected"),
+    [
+        pytest.param(
+            EXAMPLE_PROJECT / "nope",
+            ["-m", "app1.*"],
+            "no such project directory",
+            id="missing_dir",
+        ),
+        pytest.param(
+            EXAMPLE_PROJECT,
+            ["-m", "nosuch.*"],
+            "Can't import module",
+            id="unimportable",
+        ),
+        pytest.param(
+            EXAMPLE_PROJECT,
+            ["-m", "app1.zzz.*"],
+            "no modules matched",
+            id="no_match",
+        ),
+        pytest.param(
+            EXAMPLE_PROJECT,
+            ["-m", "app1.*", "--metric", "fanin"],
+            "unknown metric 'fanin'",
+            id="metric_typo",
+        ),
+        pytest.param(
+            EXAMPLE_PROJECT,
+            ["-m", "app1.*", "--metric", "depth"],
+            "compute-only",
+            id="metric_not_displayable",
+        ),
+    ],
+)
+def test_input_errors_are_reported_without_a_traceback(
+    project: Path,
+    args: list[str],
+    expected: str,
+) -> None:
+    result = run_cli(project, *args, check=False)
+    assert result.returncode == _USAGE_ERROR
+    assert expected in result.stderr
+    assert "Traceback" not in result.stderr
+    assert result.stdout == ""
+
+
+def test_metric_typo_lists_the_available_names() -> None:
+    result = run_cli(EXAMPLE_PROJECT, "-m", "app1.*", "--metric", "fanin", check=False)
+    assert "fan_in" in result.stderr
+    assert "edge_weight" in result.stderr
+
+
+def test_output_is_utf8_whatever_the_console_encoding() -> None:
+    """Cycle details contain arrows; a cp1252 console must not kill the run."""
+    result = run_cli(
+        CYCLIC_PROJECT,
+        *CYCLIC_MODULES,
+        extra_env={"PYTHONIOENCODING": "cp1252"},
+    )
+    assert result.returncode == 0
+    assert "→" in result.stdout
+
+
+def test_link_metrics_reach_cyclic_connections() -> None:
+    """A cycle stands for two links, so its label carries both values."""
+    result = run_cli(CYCLIC_PROJECT, *CYCLIC_MODULES, "--metric", "edge_weight")
+    assert "edge_weight=2/1" in result.stdout

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -76,7 +76,7 @@ class _CapturingRenderer(BlueprintRenderer):
     ) -> str:
         return ""
 
-    def _format_cycle(self, cycle: Cycle) -> CycleRender:
+    def _format_cycle(self, cycle: Cycle, decoration: LinkDecoration) -> CycleRender:
         return CycleRender(inline="")
 
     def _combine_output(
@@ -177,6 +177,22 @@ def test_pipeline_fills_in_the_cycles() -> None:
         renderer=renderer,
     ).run()
     assert len(renderer.captured.cycles) == 1
+
+
+def test_cycle_label_carries_both_directions() -> None:
+    """A cycle is one connection standing for two links, so it has two values."""
+    graph = make_graph(
+        ["a.core", "a.api", "b.util"],
+        [
+            make_edge("a.core", "b.util", "a", "b"),
+            make_edge("a.api", "b.util", "a", "b"),
+            make_edge("b.util", "a.core", "b", "a"),
+        ],
+    )
+    default_registry().compute_all(graph)
+    graph.cycles = CycleAnalyzer.detect_cycles(graph.links)
+    output = PlantUmlRenderer(plan=_plan("puml", "edge_weight")).render(graph)
+    assert "a <-[#C0392B,bold]-> b : edge_weight=2/1" in output
 
 
 def test_d2_defers_cycle_details_to_a_separate_block() -> None:


### PR DESCRIPTION
Third of six MRs.

## Silent failures

Three ways the CLI could do the wrong thing and say nothing:

```console
$ arch-blueprint examples/project_root -m 'app1.*' --metric fanin
# ...diagram, no metric anywhere, exit 0

$ arch-blueprint examples/project_root -m 'app1.zzz.*'
# ...a well-formed empty diagram, exit 0

$ arch-blueprint tests/fixtures/cyclic -m 'pkg_a.*' -m 'pkg_b.*' --metric edge_weight
# ...no metric anywhere, exit 0
```

And everything that *did* fail reached the user as a traceback.

Now:

```console
$ arch-blueprint examples/project_root -m 'app1.*' --metric fanin
arch-blueprint: unknown metric 'fanin'. Available: depth, edge_weight, fan_in, fan_out, instability
$ echo $?
2
```

Exit 2 for bad input, 1 for an analysis that could not finish. A missing project directory is checked up front — reporting it as `Can't import module 'app1.*'` explained the wrong thing.

## Metrics on cycles

The cycle branch of `_render_links` called `_format_cycle` and never built a `LinkDecoration`, so link metrics were dropped there entirely.

A cycle is one drawn connection standing for **two** links, so a link metric has two values. Showing one would make the golden freeze an arbitrary choice, so both are shown as `forward/backward`, in the order the cycle's own detail block lists them:

```
pkg_a <-[#C0392B,bold]-> pkg_b : edge_weight=2/1
note on link
  **pkg_a -> pkg_b:**
  - core → util
  - services → util
  **pkg_b -> pkg_a:**
  - util → core
end note
```

This changes the `_format_cycle` hook signature, so both renderers change with it. New scenario `cyclic_link_metrics` pins it in both formats; no existing golden moved.

## Encoding

`print(result)` died with `UnicodeEncodeError` on a non-UTF-8 console after doing all the work — cycle details contain arrows:

```console
$ PYTHONIOENCODING=cp1252 arch-blueprint tests/fixtures/cyclic -m 'pkg_a.*' -m 'pkg_b.*'
UnicodeEncodeError: 'charmap' codec can't encode character '→'
```

Output now goes through the byte layer as UTF-8. Byte-for-byte identical on a UTF-8 console, so goldens do not move. CI gains one `windows-latest` leg, because on Linux alone this path has no coverage.

## Also

- `ArchBlueprint` gains `build()` and `render()` alongside `run()`. The CLI has to see the graph to know the selection came back empty; an empty graph is a legitimate result for a library caller, not something the library should raise on.
- A D2 connection label could terminate its own statement: multiple labels were joined with `"; "` and `;` is D2's statement separator. Labels are comma-joined now and quoted when they contain a character that ends or nests a statement. **Unverified against a real `d2` binary** — none is installed here; the reasoning is from the language spec, and the change is inert unless two link metrics are requested at once.

## Verification

`pre-commit run -a` green. 74 passed, 10 xfailed. Existing goldens untouched; two new ones added for the new scenario.
