### PR TITLE
fix: stop discarding two whole classes of dependency

### DIFF
--- a/src/arch_blueprint/extract/module_extractor.py
+++ b/src/arch_blueprint/extract/module_extractor.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Iterator
+
 from arch_blueprint.domain.graph import BlueprintGraph, Edge
 from arch_blueprint.domain.node import Node, NodeKind
 from arch_blueprint.extract.base import common_depth_namespaces
@@ -21,10 +23,11 @@ class ModuleExtractor:
         nodes = [Node(id=name, kind=NodeKind.MODULE) for name in modules]
 
         selected = set(modules)
+        ancestors = {ancestor for name in modules for ancestor in self._ancestors(name)}
         edges: set[Edge] = set()
         for name in modules:
             for dep in self.source.imports_of(name):
-                if not self._is_selected(dep, selected):
+                if not self._is_selected(dep, selected, ancestors):
                     continue
                 source_ns, target_ns = common_depth_namespaces(name, dep)
                 if source_ns != target_ns:
@@ -40,18 +43,28 @@ class ModuleExtractor:
         return BlueprintGraph(nodes=nodes, edges=frozenset(edges))
 
     @staticmethod
-    def _is_selected(dep: str, selected: set[str]) -> bool:
-        """True when ``dep`` is a selected module or lives under one.
-
-        Walking ``dep``'s own dotted ancestors costs its depth, rather than a
-        scan of every selected name.
-        """
-        if dep in selected:
-            return True
-        cutoff = dep.rfind(".")
+    def _ancestors(module: str) -> Iterator[str]:
+        """Every dotted prefix of ``module``, longest first, excluding itself."""
+        cutoff = module.rfind(".")
         while cutoff != -1:
-            dep = dep[:cutoff]
-            if dep in selected:
-                return True
-            cutoff = dep.rfind(".")
-        return False
+            module = module[:cutoff]
+            yield module
+            cutoff = module.rfind(".")
+
+    @classmethod
+    def _is_selected(cls, dep: str, selected: set[str], ancestors: set[str]) -> bool:
+        """True when ``dep`` belongs to the selected set, in either direction.
+
+        Downward: ``dep`` is a selected module or lives under one.
+
+        Upward: ``dep`` is a package whose children were selected. Selecting
+        ``pkg.*`` never selects ``pkg`` itself, and ``_exclude_sub_modules``
+        removes it when it is, so a package that re-exports its children could
+        never be matched — and every import of that facade vanished.
+
+        Both directions are set lookups over the dependency's own depth; neither
+        scans the selected names.
+        """
+        if dep in selected or dep in ancestors:
+            return True
+        return any(parent in selected for parent in cls._ancestors(dep))

--- a/src/arch_blueprint/extract/source.py
+++ b/src/arch_blueprint/extract/source.py
@@ -76,13 +76,14 @@ class GrimpSource:
         return sorted(self._exclude_sub_modules(module_names))
 
     def imports_of(self, module: str) -> set[str]:
-        """All modules imported by ``module`` or any of its descendants."""
-        descendants = self.graph.find_descendants(module)
-        if not descendants:
-            return set(self.graph.find_modules_directly_imported_by(module))
+        """All modules imported by ``module`` or any of its descendants.
 
-        result: set[str] = set()
-        for descendant in descendants:
+        ``find_descendants`` excludes the module itself, so a package's own
+        ``__init__.py`` imports have to be unioned in explicitly — dropping them
+        hides every dependency a re-exporting package declares.
+        """
+        result = set(self.graph.find_modules_directly_imported_by(module))
+        for descendant in self.graph.find_descendants(module):
             result.update(self.graph.find_modules_directly_imported_by(descendant))
         return result
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,9 @@ DEEP_PROJECT = _FIXTURES / "deep_ns"
 INIT_IMPORTS_PROJECT = _FIXTURES / "init_imports"
 ANCESTOR_DEP_PROJECT = _FIXTURES / "ancestor_dep"
 
+INIT_IMPORTS_MODULES = ["-m", "writer", "-m", "storage.*"]
+ANCESTOR_DEP_MODULES = ["-m", "api.*", "-m", "services.*"]
+
 EXAMPLE_MODULES = ["-m", "app1.*", "-m", "app2.*", "-m", "plugins.**"]
 CYCLIC_MODULES = ["-m", "pkg_a.*", "-m", "pkg_b.*"]
 SHOW_METRICS = ["--metric", "fan_in", "--metric", "fan_out", "--metric", "instability"]
@@ -75,6 +78,12 @@ SCENARIOS = [
         CYCLIC_PROJECT,
         [*CYCLIC_MODULES, *SHOW_LINK_METRIC],
     ),
+    # A package whose __init__.py imports a sibling: the edge exists only if a
+    # module's own imports survive alongside its descendants'.
+    Scenario("init_imports", INIT_IMPORTS_PROJECT, INIT_IMPORTS_MODULES),
+    # An import of a package facade whose children are selected: the edge exists
+    # only if selection matches upward as well as down.
+    Scenario("ancestor_dep", ANCESTOR_DEP_PROJECT, ANCESTOR_DEP_MODULES),
 ]
 
 

--- a/tests/golden/d2/ancestor_dep.d2
+++ b/tests/golden/d2/ancestor_dep.d2
@@ -1,0 +1,15 @@
+direction: right
+api.handlers: {
+  shape: class
+  style: {
+    fill: "#2ECC71"
+  }
+}
+
+services.engine: {
+  shape: class
+  style: {
+    fill: "#2ECC71"
+  }
+}
+api -> services

--- a/tests/golden/d2/init_imports.d2
+++ b/tests/golden/d2/init_imports.d2
@@ -1,0 +1,15 @@
+direction: right
+storage.backend: {
+  shape: class
+  style: {
+    fill: "#2ECC71"
+  }
+}
+
+writer: {
+  shape: class
+  style: {
+    fill: "#3498DB"
+  }
+}
+writer -> storage

--- a/tests/golden/puml/ancestor_dep.puml
+++ b/tests/golden/puml/ancestor_dep.puml
@@ -1,0 +1,12 @@
+@startuml
+!theme amiga
+
+top to bottom direction
+hide empty members
+
+class api.handlers <<(M, #2ECC71)>>
+class services.engine <<(M, #2ECC71)>>
+
+api ---> services
+@enduml
+

--- a/tests/golden/puml/init_imports.puml
+++ b/tests/golden/puml/init_imports.puml
@@ -1,0 +1,12 @@
+@startuml
+!theme amiga
+
+top to bottom direction
+hide empty members
+
+class storage.backend <<(M, #2ECC71)>>
+class writer <<(M, #3498DB)>>
+
+writer ---> storage
+@enduml
+

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -98,20 +98,12 @@ def test_module_extractor_builds_cycle() -> None:
     assert len(CycleAnalyzer.detect_cycles(graph.links)) == 1
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="imports_of drops a module's own imports when it has descendants",
-)
 def test_package_init_imports_become_edges() -> None:
     """``writer/__init__.py`` imports storage.backend; ``writer`` has a submodule."""
     edges = _edges_of(INIT_IMPORTS_PROJECT, ["writer", "storage.*"])
     assert ("writer", "storage.backend") in edges
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="_is_selected never matches a dependency on a selected module's ancestor",
-)
 def test_import_of_package_facade_becomes_edge() -> None:
     """``api.handlers`` imports the ``services`` package, whose child is selected."""
     edges = _edges_of(ANCESTOR_DEP_PROJECT, ["api.*", "services.*"])


### PR DESCRIPTION
Fourth of six MRs. This one changes what the diagrams show.

## Two independent bugs

Both drop real imports before they can become edges. They live in different functions and neither fix touches the other.

**1. A package's own imports were thrown away.** `find_descendants` excludes the module itself, so `imports_of` returned *only* the descendants' imports whenever a module had any. A package that re-exports through its `__init__.py` declared its dependencies into a void.

**2. A dependency on a package facade could never match.** `_is_selected` matched downward only — the dependency had to be a selected module or live under one. But `pkg.*` does not select `pkg`, and `_exclude_sub_modules` removes it when a pattern does select it, so an import *of* a package whose children were selected was invisible **by construction**. Selection now matches upward too, against a precomputed ancestor set, so both directions stay lookups over the dependency's own depth rather than scans of the selected names.

## What it changes

On `_pytest`:

```
before:  279 links, 10 cycles
after:   283 links, 15 cycles
```

The five new ones were already there — they were being drawn as harmless one-way arrows:

```
_pytest.assertion     <-> _pytest.config
_pytest.cacheprovider <-> _pytest.config
_pytest.config        <-> _pytest.helpconfig
_pytest.config        <-> _pytest.hookspec
_pytest.config        <-> _pytest.terminal
```

On this repository: three edges into `arch_blueprint.metrics` appear, from `__main__`, `blueprint` and `renderer.base` — all three import the package facade, and none of them showed a dependency before.

## Regression cover

The two `xfail(strict=True)` tests added in MR 2 become ordinary passing tests. They were built to fail for *different* reasons, so fixing one could not mask the other: in the first, `imports_of('writer')` returns `[]`; in the second it correctly returns `['services']` and the extractor discards it.

Every existing golden is byte-identical, because every fixture `__init__.py` in them is empty. That is precisely why this fix would otherwise ship with no end-to-end cover, so both fixtures become scenarios with goldens of their own:

```puml
class storage.backend <<(M, #2ECC71)>>
class writer <<(M, #3498DB)>>

writer ---> storage      ← previously absent
```

## Verification

`pre-commit run -a` green. 82 passed, 10 xfailed (the remaining xfails are the undeclared-endpoint invariant, which MR 5 addresses). `_is_selected` costs 0.07 ms over 363 dependencies, so matching in both directions did not cost the lookup property MR 1 established.
