### PR TITLE
docs: record the regeneration recipes and the traps this refactor hit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,6 +31,7 @@ repos:
           - "--fix"
           - "src"
           - "tests"
+          - "scripts"
 
       - id: mypy
         name: Validate types with MyPy
@@ -41,6 +42,7 @@ repos:
         args:
           - ./src
           - ./tests
+          - ./scripts
 
       - id: pytest
         name: Run tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,13 @@ This project uses `uv` for environment and dependency management.
     `instability`) renders as a block on each node; a link metric (`edge_weight`) renders as a label
     on each connection, including cyclic ones (as `forward/backward`). An unknown name is an error,
     not a silent no-op.
+- Regenerate goldens after an *intentional* output change:
+  `uv run python scripts/regenerate_goldens.py`. Running it twice must leave the tree clean — a diff
+  on the second run means the output is not deterministic, and that is the bug to fix first.
+- Regenerate the README example images: `uv pip install --target /tmp/pkgs wemake-python-styleguide
+  fastapi taskiq`, then `uv run arch-blueprint /tmp/pkgs -m '<pkg>.*' > docs/images/<name>.puml` and
+  `plantuml -tpng docs/images/*.puml`. The committed `.puml` must stay byte-identical to what the
+  CLI emits.
 - Runnable example fixture: `uv run arch-blueprint examples/project_root -m 'app1.*' -m 'app2.*' -m 'plugins.**'`
   (see `examples/README.md`) — exercises multi-root cross-links and namespace-package handling.
 
@@ -57,6 +64,11 @@ regression is invisible on Linux alone. Runs on push to `master` and on PRs.
 - `test_golden_structure.py` — invariants the goldens must satisfy, not just their bytes: every link
   endpoint is declared, and no package wraps a class of its own name.
 
+Two scenarios look redundant and are not. `metrics_reordered` is the only one whose `--metric` order
+differs from registration order, so it is the only thing that would catch a render plan built by
+iterating the registry. `deep` is the only single-root project whose link endpoints collide with node
+ids and nest inside one another.
+
 A hand-built `BlueprintGraph` has **empty `cycles` and `groups`** until the analyze step fills them.
 A renderer test that needs either must populate them explicitly, or it will silently assert against
 ungrouped nodes and plain arrows.
@@ -66,6 +78,20 @@ Fixtures: `examples/project_root` (multi-root + PEP 420 namespace package), `tes
 and nest), `tests/fixtures/init_imports` (a package re-exporting through `__init__.py`),
 `tests/fixtures/ancestor_dep` (an import of a package facade). Fixture projects are excluded from
 ruff and mypy — they are analysis subjects, not code we ship.
+
+## Gotchas
+
+- `pre-commit run -a` reports the ruff hooks as **Failed** on the run that rewrites a file. Re-`git
+  add` and run again; a second failure is a real one.
+- Changing PlantUML output: **render a PNG and look at it**. `-syntax` / `-checkonly` only prove the
+  diagram parses. A stereotype on a `package` passes every text check while rendering as caption
+  text inside each frame — that regression shipped once and was caught only by comparing images.
+- `plantuml -syntax` ignores file arguments and reads stdin only; `-checkonly` takes files. Distro
+  builds differ: Ubuntu's `plantuml` 1.2020.02 carries no theme resources, so every golden fails
+  there on the shared `!theme amiga` header. Do not put a PlantUML check in CI — assert our own
+  invariants in `test_golden_structure.py` instead.
+- `tests/golden/` and `docs/images/` are excluded from the whitespace fixers: both hold verbatim tool
+  output, and a "fix" makes them stop matching it.
 
 ## Git conventions
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,6 +113,9 @@ exclude = [".venv/", "tests/fixtures/"]
 line-length = 88
 
 [tool.ruff.lint.per-file-ignores]
+"scripts/*" = [
+	"S603",   # subprocess call — the script exists to invoke our own CLI
+]
 "tests/*" = [
 	"S101",   # Use of assert detected
 	"S301",   # Use of pickle detected

--- a/scripts/regenerate_goldens.py
+++ b/scripts/regenerate_goldens.py
@@ -1,0 +1,53 @@
+"""Rewrite every golden from the CLI's current output.
+
+Run after an *intentional* change to what the renderers emit. Running it twice
+must leave the tree clean: if the second run produces a diff, the output is not
+deterministic and that is the bug to fix first.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from tests.conftest import SCENARIOS, golden_path  # noqa: E402
+
+FORMATS = ("puml", "d2")
+
+
+def regenerate() -> int:
+    """Write every scenario in every format; return how many files were written."""
+    written = 0
+    for scenario in SCENARIOS:
+        for fmt in FORMATS:
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "arch_blueprint",
+                    str(scenario.project),
+                    *scenario.args,
+                    "-f",
+                    fmt,
+                ],
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                check=True,
+                cwd=REPO_ROOT,
+            )
+            golden_path(fmt, scenario.name).write_text(
+                result.stdout,
+                encoding="utf-8",
+            )
+            written += 1
+    return written
+
+
+if __name__ == "__main__":
+    count = regenerate()
+    sys.stdout.write(f"regenerated {count} goldens\n")


### PR DESCRIPTION
Follow-up to the six-MR series. Documentation plus one script; no behaviour change.

`CLAUDE.md` described the finished architecture accurately but said nothing about **working on it**. Three things had to be rediscovered on every MR:

## Regenerating goldens

There was no script, so the loop got hand-written each time output changed. `scripts/regenerate_goldens.py` does it now, with the property that matters stated in its docstring: running it twice must leave the tree clean. A diff on the second run means the output is not deterministic, which is a worse bug than whatever prompted the regeneration.

## Regenerating the README images

The exact commands, plus the constraint that makes them work: the committed `.puml` must stay byte-identical to CLI output, which is why `docs/images/` sits in the whitespace fixers' exclude list beside `tests/golden/`.

## Two scenarios that look redundant

`metrics_reordered` is the only scenario whose `--metric` order differs from registration order — delete it and a render plan built by iterating the registry passes every remaining test while silently reordering everyone's diagrams. `deep` is the only single-root project whose link endpoints collide with node ids and nest.

## Gotchas

Recording what actually cost time in this series:

- `pre-commit run -a` reports the ruff hooks as **Failed** on the run that rewrites a file. Re-`git add` and run again; a second failure is a real one.
- **Do not put a PlantUML check in CI.** `-syntax` ignores file arguments and reads stdin only, `-checkonly` takes files, and Ubuntu's `plantuml` 1.2020.02 carries no theme resources — so every golden fails there on the shared `!theme amiga` header. Assert our own invariants in `test_golden_structure.py` instead.
- **For a diagram generator, parsing is not the thing to verify.** A stereotype on a `package` passes `-checkonly` while rendering as caption text inside every frame. That regression shipped in #28 and was caught only by comparing rendered images.

`scripts/` joins `src/` and `tests/` under ruff and mypy so the script cannot rot.

## Verification

`pre-commit run -a` green, 100 passed. `scripts/regenerate_goldens.py` run twice leaves the tree clean.
